### PR TITLE
enable word wrap

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,8 @@ import { GapiAuthController } from './contributions/gapiAuth';
 const domNode = document.getElementById('container');
 const editor = monaco.editor.create(domNode, {
 	value: '',
-	language: 'plaintext'
+	language: 'plaintext',
+	wordWrap: 'on'
 });
 editor.focus();
 


### PR DESCRIPTION
Hi, great app! I noticed word wrapping is off, which makes editing a lot of .txt files tricky. Since it wraps now based on the view, it shouldn't throw off code with manual line breaks too much.

(I should have done this by extending the command palette to allow users to toggle this on/off, but I ran into issues with getting the extension right there.)