### PR TITLE
Filename UI changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 *.local
+CLAUDE.md

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -24,12 +24,30 @@ export function getUrlState() {
     };
 }
 
+const SHELL_DOTFILES = new Set([
+    ".bashrc",
+    ".bash_profile",
+    ".bash_logout",
+    ".profile",
+    ".zshrc",
+    ".zprofile",
+    ".zshenv",
+    ".zlogin",
+]);
+
 /**
  * tries to get the monaco-language for a filename
  * @param {string} fileName the file name
  * @returns {string} the monaco language id, or NULL if not supported (set plaintext as fallback if needed)
  */
 export function getMonacoLanguageForFilename(fileName) {
+    if (SHELL_DOTFILES.has(fileName)) {
+        const shellLang = monaco.languages
+            .getLanguages()
+            .find((lang) => lang.id === "shell");
+        return shellLang || null;
+    }
+
     const monacoLanguages = monaco.languages.getLanguages();
     const matches = monacoLanguages.filter((lang) =>
         lang.extensions?.some((ext) => fileName.endsWith(ext))

--- a/src/commands/ToggleRenderWhitespaceAction.js
+++ b/src/commands/ToggleRenderWhitespaceAction.js
@@ -1,0 +1,32 @@
+import * as monaco from "../monaco";
+import {
+    EditorAction,
+    registerEditorAction,
+} from "monaco-editor/esm/vs/editor/browser/editorExtensions";
+import { ConfigController } from "../contributions/config";
+
+export class ToggleRenderWhitespaceAction extends EditorAction {
+    static ID = "commanditor.action.toggleRenderWhitespace";
+
+    constructor() {
+        super({
+            id: ToggleRenderWhitespaceAction.ID,
+            label: "Toggle Render Whitespace",
+            alias: "Toggle Render Whitespace",
+            precondition: undefined,
+        });
+    }
+
+    run(accessor, editor) {
+        const current = editor.getOption(
+            monaco.editor.EditorOption.renderWhitespace
+        );
+        const newValue = current === "none" ? "all" : "none";
+        ConfigController.get(editor).updateConfigValue(
+            "renderWhitespace",
+            newValue
+        );
+    }
+}
+
+registerEditorAction(ToggleRenderWhitespaceAction);

--- a/src/commands/ToggleWordWrapAction.js
+++ b/src/commands/ToggleWordWrapAction.js
@@ -3,6 +3,7 @@ import {
     EditorAction,
     registerEditorAction,
 } from "monaco-editor/esm/vs/editor/browser/editorExtensions";
+import { ConfigController } from "../contributions/config";
 
 export class ToggleWordWrapAction extends EditorAction {
     static ID = "commanditor.action.toggleWordWrap";
@@ -23,7 +24,8 @@ export class ToggleWordWrapAction extends EditorAction {
 
     run(accessor, editor) {
         const current = editor.getOption(monaco.editor.EditorOption.wordWrap);
-        editor.updateOptions({ wordWrap: current === "off" ? "on" : "off" });
+        const newValue = current === "off" ? "on" : "off";
+        ConfigController.get(editor).updateConfigValue("wordWrap", newValue);
     }
 }
 

--- a/src/commands/ToggleWordWrapAction.js
+++ b/src/commands/ToggleWordWrapAction.js
@@ -1,0 +1,30 @@
+import * as monaco from "../monaco";
+import {
+    EditorAction,
+    registerEditorAction,
+} from "monaco-editor/esm/vs/editor/browser/editorExtensions";
+
+export class ToggleWordWrapAction extends EditorAction {
+    static ID = "commanditor.action.toggleWordWrap";
+
+    constructor() {
+        super({
+            id: ToggleWordWrapAction.ID,
+            label: "Toggle Word Wrap",
+            alias: "Toggle Word Wrap",
+            precondition: undefined,
+            kbOpts: {
+                kbExpr: null,
+                primary: monaco.KeyMod.Alt | monaco.KeyCode.KeyH,
+                weight: 100,
+            },
+        });
+    }
+
+    run(accessor, editor) {
+        const current = editor.getOption(monaco.editor.EditorOption.wordWrap);
+        editor.updateOptions({ wordWrap: current === "off" ? "on" : "off" });
+    }
+}
+
+registerEditorAction(ToggleWordWrapAction);

--- a/src/contributions/config.js
+++ b/src/contributions/config.js
@@ -24,6 +24,8 @@ export class ConfigController extends Disposable {
         // wrap, font-size, minimap, ...?
         this.config = {
             theme: "vs",
+            wordWrap: "off",
+            renderWhitespace: "none",
         };
 
         // on init try to load config from local storage, its faster than fetching from drive
@@ -91,6 +93,14 @@ export class ConfigController extends Disposable {
                     this.config.theme = value;
                     monaco.editor.setTheme(value);
                     return true;
+                case "wordWrap":
+                    this.config.wordWrap = value;
+                    this._editor.updateOptions({ wordWrap: value });
+                    return true;
+                case "renderWhitespace":
+                    this.config.renderWhitespace = value;
+                    this._editor.updateOptions({ renderWhitespace: value });
+                    return true;
                 default:
                     console.error(
                         "tried to update config value without handling updating it"
@@ -115,6 +125,16 @@ export class ConfigController extends Disposable {
                     value === "vs-dark" ||
                     value === "hc-light" ||
                     value === "hc-black"
+                );
+            case "wordWrap":
+                return value === "on" || value === "off";
+            case "renderWhitespace":
+                return (
+                    value === "none" ||
+                    value === "all" ||
+                    value === "boundary" ||
+                    value === "selection" ||
+                    value === "trailing"
                 );
             default:
                 return false;

--- a/src/contributions/drive/index.js
+++ b/src/contributions/drive/index.js
@@ -49,6 +49,17 @@ export class DriveController extends Disposable {
     handleLoggedInChange(b) {
         if (!b || (b && this.state)) return;
 
+        if (import.meta.env.DEV) {
+            const devfile = new URLSearchParams(window.location.search).get("devfile");
+            if (devfile) {
+                this.currentFileInfo = { id: null, name: devfile };
+                this.setDocumentFileTitle(devfile);
+                const lang = getMonacoLanguageForFilename(devfile) || { id: "plaintext" };
+                this._editor.getModel().setMode ? this._editor.getModel().setMode(lang.id) : monaco.editor.setModelLanguage(this._editor.getModel(), lang.id);
+                return;
+            }
+        }
+
         // try to load file from url-state
         const state = getUrlState();
         this.state = state;

--- a/src/contributions/drive/index.js
+++ b/src/contributions/drive/index.js
@@ -378,7 +378,7 @@ export class DriveController extends Disposable {
             return;
         }
 
-        document.title = `commanditor (${filename})`;
+        document.title = `${filename} - commanditor`;
     }
 
     getId() {

--- a/src/contributions/gapiAuth.js
+++ b/src/contributions/gapiAuth.js
@@ -33,6 +33,10 @@ export class GapiAuthController extends Disposable {
     }
 
     loadGapi() {
+        if (import.meta.env.DEV) {
+            this.handleGapiAuthChange(true);
+            return;
+        }
         if (!!window.gapi && !!window.google) {
             window.handleClientLoad = () => {};
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import * as monaco from "./monaco";
 import "./commands/ChangeLanguageModeAction";
 import "./commands/ChangeEditorThemeAction";
 import "./commands/ToggleWordWrapAction";
+import "./commands/ToggleRenderWhitespaceAction";
 import "./contributions/editMargin";
 import "./contributions/drive";
 import "./contributions/config";

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import * as monaco from "./monaco";
 // import custom contributions and commands
 import "./commands/ChangeLanguageModeAction";
 import "./commands/ChangeEditorThemeAction";
+import "./commands/ToggleWordWrapAction";
 import "./contributions/editMargin";
 import "./contributions/drive";
 import "./contributions/config";

--- a/src/monaco.js
+++ b/src/monaco.js
@@ -53,6 +53,7 @@ import "monaco-editor/esm/vs/basic-languages/sql/sql.contribution.js";
 import "monaco-editor/esm/vs/basic-languages/swift/swift.contribution.js";
 import "monaco-editor/esm/vs/basic-languages/vb/vb.contribution.js";
 import "monaco-editor/esm/vs/basic-languages/xml/xml.contribution.js";
+import "monaco-editor/esm/vs/basic-languages/shell/shell.contribution.js";
 import "monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution.js";
 import "monaco-editor/esm/vs/basic-languages/javascript/javascript.contribution";
 import "monaco-editor/esm/vs/basic-languages/typescript/typescript.contribution";

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,6 +7,7 @@ export default defineConfig({
     server: {
         open: "/app/",
         port: 3000,
+        strictPort: true,
     },
     build: {
         rollupOptions: {


### PR DESCRIPTION
- Display filename before app name
- Intelligently use shell syntax highlighting, including on common files that don't end in `.sh`
- Add a testing mode on Dev to force-set the name of 'open file' when not connected to Drive